### PR TITLE
Added setScript() Method.

### DIFF
--- a/src/JonnyW/PhantomJs/Client.php
+++ b/src/JonnyW/PhantomJs/Client.php
@@ -115,7 +115,13 @@ class Client implements ClientInterface
 	 */
 	public function open(RequestInterface $request, ResponseInterface $response)
 	{
-		return $this->request($request, $response, $this->openCmd);
+
+        $args = func_get_args();
+        array_splice($args, 2, 0, $this->openCmd);
+
+        return call_user_func_array(array($this, "request"), $args);
+
+		//return $this->request($request, $response, $this->openCmd);
 	}
 
 	/**
@@ -209,9 +215,33 @@ class Client implements ClientInterface
                 $script = $this->writeScript($this->script);
             }
 
-			$cmd  = escapeshellcmd(sprintf("%s %s", $this->phantomJS, $script));
+            //Get the parameters passed into this function.
+            $args = func_get_args();
+            //We're unsetting the first 3 arguments, because we don't need them, and they'll mess up the rest of what we want to do.
+            //Technically we don't need to as we're overwriting them later, but just to be super safe.
+            unset($args[0], $args[1], $args[2]);
+
+            //Replace some args with PhantomJs and the Script we're firing
+            $args[1] = $this->phantomJS;
+            $args[2] = $script;
+
+            // building the format of the cmd string we'll end up producing
+            $cmdString = "";
+            foreach($args as $v){
+                $cmdString .= "%s ";
+            }
+            //get rid of that trailing space.
+            rtrim($cmdString, " ");
+            $args[0] = $cmdString;
+
+            //Sort the args by key so they aren't all messed up and screw the script up.
+            ksort($args);
+
+            // Just passing in the unknown number of args to the sprintf function
+            $cmd  = escapeshellcmd(call_user_func_array("sprintf", $args));
 
 			$result = shell_exec($cmd);
+
 			$result = $this->parse($result);
 
 			$this->removeScript($script);
@@ -286,6 +316,10 @@ class Client implements ClientInterface
 		if($data === null || !is_string($data)) {
 			return array();
 		}
+
+        if(is_string($data)){
+            return array("stringResponse" => $data);
+        }
 
 		// Not a JSON string
 		if(substr($data, 0, 1) !== '{') {

--- a/src/JonnyW/PhantomJs/Message/Response.php
+++ b/src/JonnyW/PhantomJs/Message/Response.php
@@ -66,6 +66,8 @@ class Response implements ResponseInterface
 	 */
 	protected $time;
 
+    protected $stringResponse;
+
 	/**
 	 * Set response data
 	 *
@@ -109,6 +111,11 @@ class Response implements ResponseInterface
 		if(isset($data['time'])) {
 			$this->time = $data['time'];
 		}
+
+        // Set stringResponse string
+        if(isset($data['stringResponse'])) {
+            $this->stringResponse = $data['stringResponse'];
+        }
 
 		return $this;
 	}
@@ -228,4 +235,9 @@ class Response implements ResponseInterface
 	{
 		return $this->time;
 	}
+
+    public function getCommandLine()
+    {
+        return $this->stringResponse;
+    }
 }


### PR DESCRIPTION
Due to the current limitations of the php mask for PhantomJS I needed to
build in a setScript method to be able to use more advanced
functionality.

The setScript method currently overrides all Request object data.

Example of usage (Using Laravel):

/*\*  @var $client JonnyW\PhantomJs\Client */
$client = App::make("PhantomClient");

$client->setScript("https://raw.github.com/ariya/phantomjs/master/examples/technews.js");

/*\*  @var $request JonnyW\PhantomJs\Message\Request */
$request = $client->getMessageFactory()->createRequest('GET',
'doesnotmatter.com');
$request->addHeader('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS
X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.2
Safari/534.34');

/*\*  @var $response JonnyW\PhantomJs\Message\Response */
$response = $client->getMessageFactory()->createResponse();

// Send the request
$client->send($request, $response);
