### PR TITLE
Added way to set viewport width/height

### DIFF
--- a/src/JonnyW/PhantomJs/Client.php
+++ b/src/JonnyW/PhantomJs/Client.php
@@ -204,7 +204,9 @@ class Client implements ClientInterface
                 $request->getUrl(),
                 $request->getMethod(),
                 $request->getBody(),
-                $cmd
+                $cmd,
+                $request->getViewportWidth(),
+                $request->getViewportHeight()
             );
 
             $script = $this->writeScript($data);
@@ -306,7 +308,7 @@ class Client implements ClientInterface
 
     page.settings.resourceTimeout = %2\$s;
     page.onResourceTimeout = function (e) {
-        response 		= e;
+        response         = e;
         response.status = e.errorCode;
     };
 
@@ -315,6 +317,11 @@ class Client implements ClientInterface
     };
 
     page.customHeaders = headers ? headers : {};
+            
+    page.viewportSize = {
+        width: %7\$s,
+        height: %8\$s
+    };
 
     page.open('%3\$s', '%4\$s', '%5\$s', function (status) {
 

--- a/src/JonnyW/PhantomJs/Message/Request.php
+++ b/src/JonnyW/PhantomJs/Message/Request.php
@@ -46,6 +46,20 @@ class Request implements RequestInterface
      * @var string
      */
     protected $url;
+    
+    /**
+     * Viewport width
+     *
+     * @var int
+     */
+    protected $viewportWidth;
+
+    /**
+     * Viewport height
+     *
+     * @var int
+     */
+    protected $viewportHeight;
 
     /**
      * Internal constructor
@@ -138,6 +152,62 @@ class Request implements RequestInterface
         }
 
         return $url;
+    }
+    
+    /**
+     * Set viewport width
+     *
+     * @param  string $viewport_width
+     * @return \JonnyW\PhantomJs\Message\Request
+     */
+    public function setViewportWidth($viewport_width)
+    {
+        // Validate width
+        if (!is_numeric($viewport_width)) {
+            throw new Exception('Invalid viewport width provided');
+        }
+    
+        $this->viewportWidth = $viewport_width;
+    
+        return $this;
+    }
+    
+    /**
+     * Get viewport width
+     *
+     * @return int
+     */
+    public function getViewportWidth()
+    {
+        return $this->viewportWidth ? $this->viewportWidth : 1024;
+    }
+    
+    /**
+     * Set viewport height
+     *
+     * @param  string $viewport_height
+     * @return \JonnyW\PhantomJs\Message\Request
+     */
+    public function setViewportHeight($viewport_height)
+    {
+        // Validate height
+        if (!is_numeric($viewport_height)) {
+            throw new Exception('Invalid viewport height provided');
+        }
+    
+        $this->viewportHeight = $viewport_height;
+    
+        return $this;
+    }
+    
+    /**
+     * Get viewport height
+     *
+     * @return int
+     */
+    public function getViewportHeight()
+    {
+        return $this->viewportHeight ? $this->viewportHeight : 768;
     }
 
     /**

--- a/src/JonnyW/PhantomJs/Message/RequestInterface.php
+++ b/src/JonnyW/PhantomJs/Message/RequestInterface.php
@@ -55,6 +55,36 @@ interface RequestInterface
      * @return string
      */
     public function getUrl();
+    
+    /**
+     * Set viewport width
+     *
+     * @param  int $viewport_width
+     * @return \JonnyW\PhantomJs\Message\RequestInterface
+     */
+    public function setViewportWidth($viewport_width);
+    
+    /**
+     * Get viewport width
+     *
+     * @return int
+    */
+    public function getViewportWidth();
+    
+    /**
+     * Set viewport height
+     *
+     * @param  int $viewport_height
+     * @return \JonnyW\PhantomJs\Message\RequestInterface
+     */
+    public function setViewportHeight($viewport_height);
+    
+    /**
+     * Get viewport height
+     *
+     * @return int
+    */
+    public function getViewportHeight();
 
     /**
      * Get content body


### PR DESCRIPTION
I don't know if you could already do this and it was simply missing from the README, but now you can specify the width/height of the viewport for screenshots:
$request->setViewportWidth(1024);
$request->setViewportHeight(768);
