### PR TITLE
Support for Symfony 2.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.0",
-        "symfony/config": "~2.5",
-        "symfony/dependency-injection": "~2.5",
-        "symfony/filesystem": "~2.5",
-        "symfony/yaml": "~2.5",
+        "symfony/config": "~2.3",
+        "symfony/dependency-injection": "~2.3",
+        "symfony/filesystem": "~2.3",
+        "symfony/yaml": "~2.3",
         "twig/twig": "~1.16",
         "jakoch/phantomjs-installer": "1.9.7"
     },


### PR DESCRIPTION
Symfony 2.3 is the Long Term Support version so it would be good to have php-phantomjs supporting it.
