### PR TITLE
removal of urldecode() when parsing request data fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 vendor/
 bin/phantomjs
+.idea

--- a/src/JonnyW/PhantomJs/Message/AbstractRequest.php
+++ b/src/JonnyW/PhantomJs/Message/AbstractRequest.php
@@ -283,7 +283,7 @@ abstract class AbstractRequest implements RequestInterface
             return '';
         }
 
-        return urldecode(http_build_query($this->getRequestData()));
+        return http_build_query($this->getRequestData());
     }
 
     /**


### PR DESCRIPTION
`urldecode()` is used after `http_build_query()`'ing the request data, producing unsafe non-encoded data with a high risk of malformed JS. The request data contains \ (backslash), ' (apostrophe), new line chars etc, the request breaks...

```javascript
page.open ('http://localhost:8889/charts', 'POST', 'testRequest=This breaks using this apostrophe ' plus this new line char 
 also, there should be a backslash in front of 	his', function (status) {
     ...
});
```

Removing `urldecode()` produces...

```javascript
page.open ('http://localhost:8889/charts', 'POST', 'testRequest=This+breaks+using+this+apostrophe+%27+plus+this+new+line+char+%0A+also%2C+there+should+be+a+backslash+in+front+of+%09his', function (status) {
    ...
});
```

which seemingly decodes fine on the server side.