### PR TITLE
Fixes hanging on stream_get_contents()

### DIFF
--- a/src/JonnyW/PhantomJs/Procedure/Procedure.php
+++ b/src/JonnyW/PhantomJs/Procedure/Procedure.php
@@ -95,7 +95,7 @@ class Procedure implements ProcedureInterface
             $descriptorspec = array(
                 array('pipe', 'r'),
                 array('pipe', 'w'),
-                array('pipe', 'w')
+                array('pipe', 'a')
             );
 
             $process = proc_open(escapeshellcmd(sprintf('%s %s', $client->getCommand(), $executable)), $descriptorspec, $pipes, null, null);


### PR DESCRIPTION
On certain URLs, a request is sent and received successfully, but
the script hangs when calling stream_get_contents().

Per http://php.net/manual/en/function.proc-open.php#97012
simply opening STDERR in append mode fixes this.

The commend references issue only with Windows, but have encountered
this on Ubuntu 14.04 and Debian 7.5.