### PR TITLE
Fixes JsonParser for Windows users opening batch files as they open t…

### DIFF
--- a/src/JonnyW/PhantomJs/Parser/JsonParser.php
+++ b/src/JonnyW/PhantomJs/Parser/JsonParser.php
@@ -31,7 +31,7 @@ class JsonParser implements ParserInterface
         $firstCurlyPos   = (strpos($data, "{") === false) ? -1 : strpos($data, "{");
         $firstSquaredPos = (strpos($data, "[") === false) ? -1 : strpos($data, "[");
 
-        if ($firstCurlyPos > $firstSquaredPos) {
+        if ($firstCurlyPos < $firstSquaredPos) {
             $data = strstr($data, "{");
         } else {
             $data = strstr($data, "[");

--- a/src/JonnyW/PhantomJs/Parser/JsonParser.php
+++ b/src/JonnyW/PhantomJs/Parser/JsonParser.php
@@ -28,7 +28,14 @@ class JsonParser implements ParserInterface
             return array();
         }
 
-        $data = strstr($data, "{");
+        $firstCurlyPos   = (strpos($data, "{") === false) ? -1 : strpos($data, "{");
+        $firstSquaredPos = (strpos($data, "[") === false) ? -1 : strpos($data, "[");
+
+        if ($firstCurlyPos > $firstSquaredPos) {
+            $data = strstr($data, "{");
+        } else {
+            $data = strstr($data, "[");
+        }
 
         if (substr($data, 0, 1) !== '{' &&
             substr($data, 0, 1) !== '[') {

--- a/src/JonnyW/PhantomJs/Parser/JsonParser.php
+++ b/src/JonnyW/PhantomJs/Parser/JsonParser.php
@@ -28,6 +28,8 @@ class JsonParser implements ParserInterface
             return array();
         }
 
+        $data = strstr($data, "{");
+
         if (substr($data, 0, 1) !== '{' &&
             substr($data, 0, 1) !== '[') {
             return array();


### PR DESCRIPTION
…he console prompt

I have noticed php-phantomjs breaks if you make use of the `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Command Processor` registry key in Windows that allows you to execute batch files as soon as you open the console prompt.

This small fix deletes everything before the first `{` so that the JsonParser does not break when it attempts to read the string.

## BEFORE THE FIX
```
C:\Users\Giampaolo\[...]>doskey home=cd /d "C:\Users\Giampaolo" 

C:\Users\Giampaolo\[...]>doskey vm=ssh vagrant@127.0.0.1 -p 2222 
{
    "bodySize": 63373,
    "contentType": "text/html; charset=utf-8",
    [...]
```

## AFTER THE FIX
```
{
    "bodySize": 63373,
    "contentType": "text/html; charset=utf-8",
    [...]
```