### PR TITLE
update jakoch/phantomjs-installer to v2.1.1-p07

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/filesystem": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
         "twig/twig": "~1.16",
-        "jakoch/phantomjs-installer": "2.1.1"
+        "jakoch/phantomjs-installer": "2.1.1-p07"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
**Changes in the installer**
- indicate the need for php-ext bzip2 (solves extraction issue)
- change of the download URL (this solves bitbucket issues)
- [CDN / mirror support](https://github.com/jakoch/phantomjs-installer#downloading-from-a-mirror)
- [override platform requirements (package for other os)](https://github.com/jakoch/phantomjs-installer#override-platform-requirements)
- easy access to the [PhantomBinary via class constant](https://github.com/jakoch/phantomjs-installer#phantombinary) (could be useful for this project)

[CHANGELOG](https://github.com/jakoch/phantomjs-installer/blob/master/Changelog.md) - [README](https://github.com/jakoch/phantomjs-installer/blob/master/README.md)