### PR TITLE
Removes the dependency on the /bin hardcoded path.

### DIFF
--- a/src/JonnyW/PhantomJs/Engine.php
+++ b/src/JonnyW/PhantomJs/Engine.php
@@ -9,6 +9,7 @@
 namespace JonnyW\PhantomJs;
 
 use JonnyW\PhantomJs\Exception\InvalidExecutableException;
+use PhantomInstaller\PhantomBinary;
 
 /**
  * PHP PhantomJs
@@ -65,7 +66,7 @@ class Engine
      */
     public function __construct()
     {
-        $this->path    = 'bin/phantomjs';
+        $this->path    = PhantomBinary::BIN;
         $this->options = array();
 
         $this->debug = false;

--- a/src/JonnyW/PhantomJs/Tests/Unit/EngineTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/EngineTest.php
@@ -9,6 +9,7 @@
 namespace JonnyW\PhantomJs\Tests\Unit;
 
 use JonnyW\PhantomJs\Engine;
+use PhantomInstaller\PhantomBinary;
 
 /**
  * PHP PhantomJs
@@ -48,7 +49,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
     {
         $engine = $this->getEngine();
 
-        $this->assertSame('bin/phantomjs', $engine->getPath());
+        $this->assertSame(PhantomBinary::BIN, $engine->getPath());
     }
 
     /**


### PR DESCRIPTION
The original code assumes you will want to install binaries at /bin but probably this is not the case if you follow the defaults in composer, which will install them in /vendor/bin.

You now can have the PhantomJs in /vendor/bin if you prefer, or even at any other path, and the Engine will automatically fetch it from the proper path via the PhantomInstaller\PhantomBinary helper class.