### PR TITLE
Twig2 + PHPUnit 6 + Local Timezone Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ os:
   - windows
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "jakoch/phantomjs-installer": "2.1.1-p08"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~6.0",
         "zendframework/zendpdf": "~2.0",
         "smalot/pdfparser": "~0.9"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/filesystem": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
-        "twig/twig": "~1.16",
+        "twig/twig": "~1.16|~2",
         "jakoch/phantomjs-installer": "2.1.1-p08"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,10 @@
     processIsolation            = "false"
     stopOnFailure               = "true"
     syntaxCheck                 = "false">
+
+    <php>
+      <env name="TZ" value="GMT"/>
+    </php>
     <testsuites>
         <testsuite name="PhantomJS Test Suite">
             <directory suffix="Test.php">./src/JonnyW/PhantomJs/Tests/*</directory>

--- a/src/JonnyW/PhantomJs/Procedure/Procedure.php
+++ b/src/JonnyW/PhantomJs/Procedure/Procedure.php
@@ -93,10 +93,10 @@ class Procedure implements ProcedureInterface
     public function run(InputInterface $input, OutputInterface $output)
     {
         try {
-
             $executable = $this->write(
                 $this->compile($input)
             );
+            
 
             $descriptorspec = array(
                 array('pipe', 'r'),

--- a/src/JonnyW/PhantomJs/Test/TestCase.php
+++ b/src/JonnyW/PhantomJs/Test/TestCase.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\DependencyInjection\ServiceContainer;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Get dependency injection container.

--- a/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
@@ -119,7 +119,7 @@ EOF;
      */
     public function testSyntaxExceptionIsThrownIfRequestProcedureContainsSyntaxError()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\SyntaxException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\SyntaxException');
 
         $content = 'TEST_PROCEDURE';
 

--- a/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
@@ -11,6 +11,7 @@ namespace JonnyW\PhantomJs\Tests\Integration;
 use JonnyW\PhantomJs\Test\TestCase;
 use JonnyW\PhantomJs\Client;
 use JonnyW\PhantomJs\DependencyInjection\ServiceContainer;
+use DateTime;
 
 /**
  * PHP PhantomJs
@@ -34,6 +35,9 @@ class ClientTest extends TestCase
      * @access protected
      */
     protected $directory;
+
+
+
 
 /** +++++++++++++++++++++++++++++++++++ **/
 /** ++++++++++++++ TESTS ++++++++++++++ **/
@@ -385,8 +389,9 @@ EOF;
         $cookies = $response->getCookies();
         $this->assertEquals(array(
             'domain' => '.jonnyw.kiwi',
-            'expires' => 'Mon, 16 Nov 2020 00:00:00 GMT',
-            'expiry' => '1605484800',
+
+            'expires' => date(DateTime::COOKIE, 1605484800),
+            'expiry' => 1605484800,
             'httponly' => true,
             'name' => 'test_cookie',
             'path' => '/',
@@ -1156,6 +1161,8 @@ EOF;
     {
         $this->filename  = 'test.proc';
         $this->directory = sys_get_temp_dir();
+
+        date_default_timezone_set('GMT');
 
         if (!is_writable($this->directory)) {
             throw new \RuntimeException(sprintf('Test directory must be writable: %s', $this->directory));

--- a/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/ClientTest.php
@@ -13,6 +13,8 @@ use JonnyW\PhantomJs\Client;
 use JonnyW\PhantomJs\DependencyInjection\ServiceContainer;
 use DateTime;
 
+
+
 /**
  * PHP PhantomJs
  *
@@ -35,7 +37,6 @@ class ClientTest extends TestCase
      * @access protected
      */
     protected $directory;
-
 
 
 
@@ -389,8 +390,7 @@ EOF;
         $cookies = $response->getCookies();
         $this->assertEquals(array(
             'domain' => '.jonnyw.kiwi',
-
-            'expires' => date(DateTime::COOKIE, 1605484800),
+            'expires' => 'Mon, 16 Nov 2020 00:00:00 GMT',
             'expiry' => 1605484800,
             'httponly' => true,
             'name' => 'test_cookie',

--- a/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureCompilerTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureCompilerTest.php
@@ -60,7 +60,7 @@ class ProcedureCompilerTest extends \PHPUnit\Framework\TestCase
         $request = $this->getRequest();
         $request->setUrl('http://test.com');
 
-        $renderer = $this->getMock('\JonnyW\PhantomJs\Template\TemplateRendererInterface');
+        $renderer = $this->getMockBuilder('\JonnyW\PhantomJs\Template\TemplateRendererInterface')->getMock();
         $renderer->expects($this->exactly(1))
             ->method('render')
             ->will($this->returnValue('var test=1; phantom.exit(1);'));
@@ -94,7 +94,7 @@ class ProcedureCompilerTest extends \PHPUnit\Framework\TestCase
         $request = $this->getRequest();
         $request->setUrl('http://test.com');
 
-        $renderer = $this->getMock('\JonnyW\PhantomJs\Template\TemplateRendererInterface');
+        $renderer = $this->getMockBuilder('\JonnyW\PhantomJs\Template\TemplateRendererInterface')->getMock();
         $renderer->expects($this->exactly(2))
             ->method('render')
             ->will($this->returnValue('var test=1; phantom.exit(1);'));
@@ -127,7 +127,7 @@ class ProcedureCompilerTest extends \PHPUnit\Framework\TestCase
         $request = $this->getRequest();
         $request->setUrl('http://test.com');
 
-        $renderer = $this->getMock('\JonnyW\PhantomJs\Template\TemplateRendererInterface');
+        $renderer = $this->getMockBuilder('\JonnyW\PhantomJs\Template\TemplateRendererInterface')->getMock();
         $renderer->expects($this->exactly(2))
             ->method('render')
             ->will($this->returnValue('var test=1; phantom.exit(1);'));

--- a/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureCompilerTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureCompilerTest.php
@@ -17,7 +17,7 @@ use JonnyW\PhantomJs\DependencyInjection\ServiceContainer;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureCompilerTest extends \PHPUnit_Framework_TestCase
+class ProcedureCompilerTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -155,7 +155,7 @@ class ProcedureCompilerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSyntaxExceptionIsThrownIfCompiledTemplateIsNotValid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\SyntaxException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\SyntaxException');
 
         $template = <<<EOF
     console.log(;

--- a/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureValidatorTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Integration/Procedure/ProcedureValidatorTest.php
@@ -21,7 +21,7 @@ use JonnyW\PhantomJs\Validator\EngineInterface;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureValidatorTest extends \PHPUnit_Framework_TestCase
+class ProcedureValidatorTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -38,7 +38,7 @@ class ProcedureValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcedureSyntaxExceptionIsThrownIfProcedureContainsSyntaxError()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\SyntaxException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\SyntaxException');
 
         $procedureLoader = $this->getProcedureLoader();
         $esprima         = $this->getEsprima();
@@ -78,7 +78,7 @@ class ProcedureValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequirementExceptionIsThrownIfProcedureDoesNotContainPhanomtExitStatement()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\RequirementException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\RequirementException');
 
         $procedureLoader = $this->getProcedureLoader();
         $esprima         = $this->getEsprima();

--- a/src/JonnyW/PhantomJs/Tests/Unit/Cache/FileCacheTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Cache/FileCacheTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Cache\FileCache;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class FileCacheTest extends \PHPUnit_Framework_TestCase
+class FileCacheTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test filename
@@ -74,7 +74,7 @@ class FileCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotWritableExceptionIsThrownIfFileCannotBeSavedDueToWritePermissions()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotWritableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $fileCache = $this->getFileCache('/This/Directory/Is/Not/Writable/', 'txt');
         $fileCache->save($this->filename, 'Test');
@@ -122,7 +122,7 @@ class FileCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotWritableExceptionIsThrownIfDirectoryPathIsNotWritable()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotWritableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $fileCache  = $this->getFileCache($this->directory, 'txt');
         $file       = $fileCache->save('/This/Directory/Is/Not/Writable/', 'Test');
@@ -156,7 +156,7 @@ class FileCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotExistsExceptionIsThrownIfWhenFetchingDataThatDoesntExist()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotExistsException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotExistsException');
 
         $fileCache = $this->getFileCache('', 'txt');
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/ClientTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/ClientTest.php
@@ -19,7 +19,7 @@ use JonnyW\PhantomJs\Procedure\ProcedureCompilerInterface;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/ClientTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/ClientTest.php
@@ -121,7 +121,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     protected function getEngine()
     {
-        $engine = $this->getMock('\JonnyW\PhantomJs\Engine');
+        $engine = $this->getMockBuilder('\JonnyW\PhantomJs\Engine')->getMock();
 
         return $engine;
     }
@@ -134,7 +134,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMessageFactory()
     {
-        $messageFactory = $this->getMock('\JonnyW\PhantomJs\Http\MessageFactoryInterface');
+        $messageFactory = $this->getMockBuilder('\JonnyW\PhantomJs\Http\MessageFactoryInterface')->getMock();
 
         return $messageFactory;
     }
@@ -147,7 +147,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     protected function getProcedureLoader()
     {
-        $procedureLoader = $this->getMock('\JonnyW\PhantomJs\Procedure\ProcedureLoaderInterface');
+        $procedureLoader = $this->getMockBuilder('\JonnyW\PhantomJs\Procedure\ProcedureLoaderInterface')->getMock();
 
         return $procedureLoader;
     }
@@ -160,7 +160,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     protected function getProcedureCompiler()
     {
-        $procedureCompiler = $this->getMock('\JonnyW\PhantomJs\Procedure\ProcedureCompilerInterface');
+        $procedureCompiler = $this->getMockBuilder('\JonnyW\PhantomJs\Procedure\ProcedureCompilerInterface')->getMock();
 
         return $procedureCompiler;
     }

--- a/src/JonnyW/PhantomJs/Tests/Unit/EngineTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/EngineTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Engine;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class EngineTest extends \PHPUnit_Framework_TestCase
+class EngineTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -31,7 +31,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidExecutableExceptionIsThrownIfPhantomJSPathIsInvalid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\InvalidExecutableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\InvalidExecutableException');
 
         $engine = $this->getEngine();
         $engine->setPath('/invalid/phantomjs/path');
@@ -115,7 +115,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidExecutableExceptionIsThrownWhenBuildingCommandIfPathToPhantomJSIsInvalid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\InvalidExecutableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\InvalidExecutableException');
 
         $engine = $this->getEngine();
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Http/CaptureRequestTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Http/CaptureRequestTest.php
@@ -16,7 +16,7 @@ use JonnyW\PhantomJs\Http\RequestInterface;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class CaptureRequestTest extends \PHPUnit_Framework_TestCase
+class CaptureRequestTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -104,7 +104,7 @@ class CaptureRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMethodIsThrownIfMethodIsInvalid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
 
         $captureRequest = $this->getCaptureRequest();
         $captureRequest->setMethod('INVALID_METHOD');
@@ -473,7 +473,7 @@ class CaptureRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotWritableExceptonIsThrownIfOutputPathIsNotWritable()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotWritableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $invalidPath = '/invalid/path';
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Http/MessageFactoryTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Http/MessageFactoryTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Http\MessageFactory;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class MessageFactoryTest extends \PHPUnit_Framework_TestCase
+class MessageFactoryTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Http/PdfRequestTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Http/PdfRequestTest.php
@@ -16,7 +16,7 @@ use JonnyW\PhantomJs\Http\RequestInterface;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class PdfRequestTest extends \PHPUnit_Framework_TestCase
+class PdfRequestTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -104,7 +104,7 @@ class PdfRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMethodIsThrownIfMethodIsInvalid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
 
         $pdfRequest = $this->getPdfRequest();
         $pdfRequest->setMethod('INVALID_METHOD');
@@ -403,7 +403,7 @@ class PdfRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function tesNotWritableExceptonIsThrownIfOutputPathIsNotWritable()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotWritableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $invalidPath = '/invalid/path';
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Http/RequestTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Http/RequestTest.php
@@ -16,7 +16,7 @@ use JonnyW\PhantomJs\Http\RequestInterface;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -104,7 +104,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMethodIsThrownIfMethodIsInvalid()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\InvalidMethodException');
 
         $request = $this->getRequest();
         $request->setMethod('INVALID_METHOD');

--- a/src/JonnyW/PhantomJs/Tests/Unit/Http/ResponseTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Http/ResponseTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Http\Response;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Parser/JsonParserTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Parser/JsonParserTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Parser\JsonParser;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class JsonParserTest extends \PHPUnit_Framework_TestCase
+class JsonParserTest extends \PHPUnit\Framework\TestCase
 {
 
 /*****************/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ChainProcedureLoaderTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ChainProcedureLoaderTest.php
@@ -153,7 +153,7 @@ class ChainProcedureLoaderTest extends \PHPUnit\Framework\TestCase
      */
     protected function getProcedureLoader()
     {
-        $procedureLoader = $this->getMock('\JonnyW\PhantomJs\Procedure\ProcedureLoaderInterface');
+        $procedureLoader = $this->getMockBuilder('\JonnyW\PhantomJs\Procedure\ProcedureLoaderInterface')->getMock();
 
         return $procedureLoader;
     }
@@ -166,7 +166,7 @@ class ChainProcedureLoaderTest extends \PHPUnit\Framework\TestCase
      */
     protected function getProcedure()
     {
-        $procedure = $this->getMock('\JonnyW\PhantomJs\Procedure\ProcedureInterface');
+        $procedure = $this->getMockBuilder('\JonnyW\PhantomJs\Procedure\ProcedureInterface')->getMock();
 
         return $procedure;
     }

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ChainProcedureLoaderTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ChainProcedureLoaderTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Procedure\ChainProcedureLoader;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ChainProcedureLoaderTest extends \PHPUnit_Framework_TestCase
+class ChainProcedureLoaderTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -31,7 +31,7 @@ class ChainProcedureLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfNoValidLoaderCanBeFound()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $procedureLoaders = array();
 
@@ -91,7 +91,7 @@ class ChainProcedureLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfNoValidLoaderCanBeFoundWhenLoadingTemplate()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $procedureLoaders = array();
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/InputTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/InputTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Procedure\Input;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class InputTest extends \PHPUnit_Framework_TestCase
+class InputTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/OutputTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/OutputTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\Procedure\Output;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class OutputTest extends \PHPUnit_Framework_TestCase
+class OutputTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureFactoryTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureFactoryTest.php
@@ -9,7 +9,6 @@
 namespace JonnyW\PhantomJs\Tests\Unit\Procedure;
 
 use Twig_Environment;
-use Twig_Loader_String;
 use JonnyW\PhantomJs\Engine;
 use JonnyW\PhantomJs\Cache\FileCache;
 use JonnyW\PhantomJs\Cache\CacheInterface;
@@ -121,11 +120,9 @@ class ProcedureFactoryTest extends \PHPUnit_Framework_TestCase
     protected function getRenderer()
     {
         $twig = new Twig_Environment(
-            new Twig_Loader_String()
+            new \Twig_Loader_Array([])
         );
-
         $renderer = new TemplateRenderer($twig);
-
         return $renderer;
     }
 }

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureFactoryTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureFactoryTest.php
@@ -23,7 +23,7 @@ use JonnyW\PhantomJs\Procedure\ProcedureFactory;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureFactoryTest extends \PHPUnit_Framework_TestCase
+class ProcedureFactoryTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderFactoryTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderFactoryTest.php
@@ -16,7 +16,7 @@ use JonnyW\PhantomJs\Procedure\ProcedureLoaderFactory;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureLoaderFactoryTest extends \PHPUnit_Framework_TestCase
+class ProcedureLoaderFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test directory
@@ -39,7 +39,7 @@ class ProcedureLoaderFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfDirectoryIsNotReadableWhenCreatingProcedureLoader()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $procedureFactory = $this->getProcedureFactory();
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderFactoryTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderFactoryTest.php
@@ -93,7 +93,7 @@ class ProcedureLoaderFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function getProcedureFactory()
     {
-        $procedureFactory = $this->getMock('\JonnyW\PhantomJs\Procedure\ProcedureFactoryInterface');
+        $procedureFactory = $this->getMockBuilder('\JonnyW\PhantomJs\Procedure\ProcedureFactoryInterface')->getMock();
 
         return $procedureFactory;
     }

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
@@ -266,7 +266,7 @@ class ProcedureLoaderTest extends \PHPUnit\Framework\TestCase
      */
     protected function getFileLocator()
     {
-        $fileLocator = $this->getMock('\Symfony\Component\Config\FileLocatorInterface');
+        $fileLocator = $this->getMockBuilder('\Symfony\Component\Config\FileLocatorInterface')->getMock();
 
         return $fileLocator;
     }

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
@@ -26,7 +26,7 @@ use JonnyW\PhantomJs\Procedure\ProcedureLoader;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureLoaderTest extends \PHPUnit_Framework_TestCase
+class ProcedureLoaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test filename
@@ -57,7 +57,7 @@ class ProcedureLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfProcedureFileIsNotLocal()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $procedureFactory = $this->getProcedureFactory();
         $fileLocator      = $this->getFileLocator();
@@ -78,7 +78,7 @@ class ProcedureLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotExistsExceptionIsThrownIfProcedureFileDoesNotExist()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotExistsException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotExistsException');
 
         $procedureFactory = $this->getProcedureFactory();
         $fileLocator      = $this->getFileLocator();

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureLoaderTest.php
@@ -9,7 +9,6 @@
 namespace JonnyW\PhantomJs\Tests\Unit\Procedure;
 
 use Twig_Environment;
-use Twig_Loader_String;
 use Symfony\Component\Config\FileLocatorInterface;
 use JonnyW\PhantomJs\Engine;
 use JonnyW\PhantomJs\Cache\FileCache;
@@ -248,9 +247,8 @@ class ProcedureLoaderTest extends \PHPUnit_Framework_TestCase
     protected function getRenderer()
     {
         $twig = new Twig_Environment(
-            new Twig_Loader_String()
+            new \Twig_Loader_Array([])
         );
-
         $renderer = new TemplateRenderer($twig);
 
         return $renderer;

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
@@ -87,6 +87,8 @@ class ProcedureTest extends \PHPUnit\Framework\TestCase
      */
     public function testNotWritableExceptionIsThrownIfProcedureScriptCannotBeWrittenToFile()
     {
+        $template = 'TEST_{{ input.get("uncompiled") }}_PROCEDURE';
+
         $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $engne    = $this->getEngine();
@@ -99,6 +101,7 @@ class ProcedureTest extends \PHPUnit\Framework\TestCase
         $output = $this->getOutput();
 
         $procedure = $this->getProcedure($engne, $parser, $cache, $renderer);
+        $procedure->setTemplate($template);
         $procedure->run($input, $output);
     }
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
@@ -87,7 +87,7 @@ class ProcedureTest extends \PHPUnit\Framework\TestCase
      */
     public function testNotWritableExceptionIsThrownIfProcedureScriptCannotBeWrittenToFile()
     {
-        $template = 'TEST_{{ input.get("uncompiled") }}_PROCEDURE';
+        $template = 'TEST_NOT_WRITABLE_PROCEDURE';
 
         $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
@@ -25,7 +25,7 @@ use JonnyW\PhantomJs\Procedure\Procedure;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class ProcedureTest extends \PHPUnit_Framework_TestCase
+class ProcedureTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -87,7 +87,7 @@ class ProcedureTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotWritableExceptionIsThrownIfProcedureScriptCannotBeWrittenToFile()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\NotWritableException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\NotWritableException');
 
         $engne    = $this->getEngine();
         $parser   = $this->getParser();
@@ -111,7 +111,7 @@ class ProcedureTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcedureFailedExceptionIsThrownIfProcedureCannotBeRun()
     {
-        $this->setExpectedException('\JonnyW\PhantomJs\Exception\ProcedureFailedException');
+        $this->expectException('\JonnyW\PhantomJs\Exception\ProcedureFailedException');
 
         $parser   = $this->getParser();
         $cache    = $this->getCache();

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
@@ -9,7 +9,6 @@
 namespace JonnyW\PhantomJs\Tests\Unit\Procedure;
 
 use Twig_Environment;
-use Twig_Loader_String;
 use JonnyW\PhantomJs\Engine;
 use JonnyW\PhantomJs\Cache\FileCache;
 use JonnyW\PhantomJs\Cache\CacheInterface;
@@ -185,9 +184,7 @@ class ProcedureTest extends \PHPUnit_Framework_TestCase
      */
     protected function getRenderer()
     {
-        $twig = new Twig_Environment(
-            new Twig_Loader_String()
-        );
+        $twig = new Twig_Environment( new \Twig_Loader_Array([]) );
 
         $renderer = new TemplateRenderer($twig);
 

--- a/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Procedure/ProcedureTest.php
@@ -229,7 +229,7 @@ class ProcedureTest extends \PHPUnit\Framework\TestCase
      */
     protected function getEngine()
     {
-        $engine = $this->getMock('\JonnyW\PhantomJs\Engine');
+        $engine = $this->getMockBuilder('\JonnyW\PhantomJs\Engine')->getMock();
 
         return $engine;
     }

--- a/src/JonnyW/PhantomJs/Tests/Unit/StringUtilsTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/StringUtilsTest.php
@@ -15,7 +15,7 @@ use JonnyW\PhantomJs\StringUtils;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class StringUtilsTest extends \PHPUnit_Framework_TestCase
+class StringUtilsTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Template/TemplateRendererTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Template/TemplateRendererTest.php
@@ -17,7 +17,7 @@ use JonnyW\PhantomJs\Template\TemplateRenderer;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class TemplateRendererTest extends \PHPUnit_Framework_TestCase
+class TemplateRendererTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/

--- a/src/JonnyW/PhantomJs/Tests/Unit/Template/TemplateRendererTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Template/TemplateRendererTest.php
@@ -9,7 +9,6 @@
 namespace JonnyW\PhantomJs\Tests\Unit\Template;
 
 use Twig_Environment;
-use Twig_Loader_String;
 use JonnyW\PhantomJs\Http\Request;
 use JonnyW\PhantomJs\Template\TemplateRenderer;
 
@@ -139,10 +138,7 @@ class TemplateRendererTest extends \PHPUnit_Framework_TestCase
      */
     protected function getTwig()
     {
-        $twig = new Twig_Environment(
-            new Twig_Loader_String()
-        );
-
+        $twig = new Twig_Environment(new \Twig_Loader_Array([]));
         return $twig;
     }
 }

--- a/src/JonnyW/PhantomJs/Tests/Unit/Validator/EsprimaTest.php
+++ b/src/JonnyW/PhantomJs/Tests/Unit/Validator/EsprimaTest.php
@@ -16,7 +16,7 @@ use JonnyW\PhantomJs\Validator\Esprima;
  *
  * @author Jon Wenmoth <contact@jonnyw.me>
  */
-class EsprimaTest extends \PHPUnit_Framework_TestCase
+class EsprimaTest extends \PHPUnit\Framework\TestCase
 {
 
 /** +++++++++++++++++++++++++++++++++++ **/
@@ -32,7 +32,7 @@ class EsprimaTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentExceptionIsThrownIfFilePathIsNotLocalFile()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $fileLocator = $this->getFileLocator();
         $esprima     = $this->getEsprima($fileLocator, 'http://example.com');
@@ -49,7 +49,7 @@ class EsprimaTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentIsThrownIfFileDoesNotExist()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $fileLocator = $this->getFileLocator();
         $esprima     = $this->getEsprima($fileLocator, 'invalidFile.js');


### PR DESCRIPTION
Please take a look.

- Fixes phpunit6 issues
- Upgrades twig to 2.x
- Fixes phantomjs cookie timezone issue from phpunit config. (set default timezone GMT in phpunit.xml.dist)
- Fixes #190 