### PR TITLE
Symfony compatibility: remove wrongly overridden "load()" method but preserve the logic

### DIFF
--- a/src/JonnyW/PhantomJs/DependencyInjection/ServiceContainer.php
+++ b/src/JonnyW/PhantomJs/DependencyInjection/ServiceContainer.php
@@ -22,7 +22,7 @@ class ServiceContainer extends ContainerBuilder
     /**
      * Service container instance
      *
-     * @var \JonnyW\PhantomJs\DependencyInjection\ServiceContainer
+     * @var static
      * @access private
      */
     private static $instance;
@@ -31,32 +31,21 @@ class ServiceContainer extends ContainerBuilder
      * Get singleton instance
      *
      * @access public
-     * @return \JonnyW\PhantomJs\Client
+     * @return static
      */
     public static function getInstance()
     {
-        if (!self::$instance instanceof ServiceContainer) {
+        if (null === self::$instance) {
+            self::$instance = new static();
 
-            self::$instance = new ServiceContainer();
-            self::$instance->load();
+            $loader = new YamlFileLoader(self::$instance, new FileLocator(__DIR__.'/../Resources/config'));
+            $loader->load('config.yml');
+            $loader->load('services.yml');
+
+            self::$instance->setParameter('phantomjs.cache_dir', sys_get_temp_dir());
+            self::$instance->setParameter('phantomjs.resource_dir', __DIR__.'/../Resources');
         }
 
         return self::$instance;
-    }
-
-    /**
-     * Load service container.
-     *
-     * @access public
-     * @return void
-     */
-    public function load()
-    {
-        $loader = new YamlFileLoader($this, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('config.yml');
-        $loader->load('services.yml');
-
-        $this->setParameter('phantomjs.cache_dir', sys_get_temp_dir());
-        $this->setParameter('phantomjs.resource_dir', __DIR__.'/../Resources');
     }
 }


### PR DESCRIPTION
This PR is aimed to fix the next critical issue:

```
In ServiceContainer.php line 20:

  [Symfony\Component\Debug\Exception\ContextErrorException]
  Warning: Declaration of JonnyW\PhantomJs\DependencyInjection\ServiceContainer::load() should be compatible with Symfony\Component\DependencyInjection\Container::load($file)
```

By the meaning it duplicates #235 but has no extra changes.