### PR TITLE
fix blocks infinitly under Windows

### DIFF
--- a/src/JonnyW/PhantomJs/Procedure/Procedure.php
+++ b/src/JonnyW/PhantomJs/Procedure/Procedure.php
@@ -101,7 +101,7 @@ class Procedure implements ProcedureInterface
             $descriptorspec = array(
                 array('pipe', 'r'),
                 array('pipe', 'w'),
-                array('pipe', 'w')
+                array('pipe', 'a')
             );
 
             $process = proc_open(escapeshellcmd(sprintf('%s %s', $this->engine->getCommand(), $executable)), $descriptorspec, $pipes, null, null);


### PR DESCRIPTION
It seems that stream_get_contents() on STDOUT blocks infinitly under Windows when STDERR is filled under some circumstances.
reference: https://www.php.net/manual/zh/function.proc-open.php#97012